### PR TITLE
Use ListenAndServe without TLS in API

### DIFF
--- a/cmd/tapir-analyse-looptest/main.go
+++ b/cmd/tapir-analyse-looptest/main.go
@@ -101,10 +101,6 @@ func main() {
 		logger.Conf{
 			Debug: debugFlag || mainConf.Nats.Debug,
 		})
-	if err != nil {
-		log.Error("Error creating nats log: %s", err)
-		os.Exit(-1)
-	}
 
 	envNatsUrl, overrideNatsUrl := os.LookupEnv(env_DNSTAPIR_NATS_URL)
 	if overrideNatsUrl {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -84,7 +84,7 @@ func (a *apiHandle) Run(ctx context.Context, exitCh chan<- common.Exit) {
 	go func() {
 		defer wg.Done()
 
-		err = srv.ListenAndServeTLS("", "")
+		err = srv.ListenAndServe()
 		if errors.Is(err, http.ErrServerClosed) {
 			a.log.Info("API server closing")
 			err = nil
@@ -96,8 +96,12 @@ func (a *apiHandle) Run(ctx context.Context, exitCh chan<- common.Exit) {
 
 	<-ctx.Done()
 	a.log.Info("Shutting down API")
-	shutdownCtx, _ := context.WithTimeout(context.Background(), time.Second*2)
-	srv.Shutdown(shutdownCtx)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	err = srv.Shutdown(shutdownCtx)
+	if err != nil {
+		a.log.Error("Bad API server shutdown: '%s'", err)
+	}
 	wg.Wait()
 
 	exitCh <- common.Exit{ID: a.id, Err: err}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a stale startup error check that could produce false error reports.
  * Improved server shutdown handling with proper context cleanup and error reporting.

* **API Changes**
  * The API server now starts without TLS enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->